### PR TITLE
Updated stationary combustion page with new units and new categories.

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -31,7 +31,7 @@
         "tailwindcss": "^3.4.1",
         "typescript": "~5.7.2",
         "typescript-eslint": "^8.22.0",
-        "vite": "^6.1.0"
+        "vite": "^6.2.2"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -4431,9 +4431,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.0.tgz",
-      "integrity": "sha512-7dPxoo+WsT/64rDcwoOjk76XHj+TqNTIvHKcuMQ1k4/SeHDaQt5GFAeLYzrimZrMpn/O6DtdI03WUjdxuPM0oQ==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.2.tgz",
+      "integrity": "sha512-yW7PeMM+LkDzc7CgJuRLMW2Jz0FxMOsVJ8Lv3gpgW9WLcb9cTW+121UEr1hvmfR7w3SegR5ItvYyzVz1vxNJgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,6 @@
     "tailwindcss": "^3.4.1",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.22.0",
-    "vite": "^6.1.0"
+    "vite": "^6.2.2"
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -30,6 +30,34 @@ const App: React.FC = () => {
             Scope 1 - Stationary Combustion
           </h2>
 
+          {/* Natural Gas seems so important and widely used it should have its own category. */}
+          <ScopeSection
+            title="Natural Gas"
+            description="Natural gas is a common fuel used by companies for heating, power generation and industrial processes. Report your usage in units like cubic meters, MCF, or MMBtu."
+          />
+
+          <ScopeSection
+            title="Solid Fuels"
+            description="Solid fuels -- including various types of coal, coke, and waste-derived fuels -- are commonly used by companies for power generation and industrial heating. Report your usage in weight units 
+                          (e.g., metric tons, short tons, kilograms) or in energy units such as MMMBtu"
+            />
+
+            <ScopeSection
+              title="Liquid Fuels"
+              description="Liquid fuels -- such as distillate fuel oil, residual fuel oil, kerosene, LPG, biodiesel, and ethanol -- are commonly used by companies for heating, power generation, and various industrial processes. 
+                              Report your usage in volume (e.g., gallons, liters, barrels), weight (e.g., kilograms), or energy (e.g., MMBtu). "
+            />
+
+            {/* Note that natural gas should not be included here as it has its own category. */}
+            <ScopeSection
+              title="Gaseous Fuels"
+              description="Gaseous fuels -- including blast furnace gas, coke oven gas, fuel gas, propane gas, landfill gas, and other biomass gases -- are used in industrial processes and power generation. 
+                              Report your usage in units such as cubic meters, MCF, or MMBtu. "
+            />
+
+
+{/* Old Front End with different categories, feel free to remove once done
+
           <ScopeSection
             title="Fossil Fuels"
             description="These are fuels like coal, oil, and natural gas. Enter the amount your company burns (in units like ***) from the specific fossil fuel type you use."
@@ -48,7 +76,7 @@ const App: React.FC = () => {
           <ScopeSection
             title="Other Fuels - Gaseous"
             description="These gases are byproducts or specialzed fuels like blast furnace gas, coke oven gas, fuel gas, and propane gas. Input the *** consumed in your operations."
-          />
+          /> */}
 
           {/* Moved button below ScopeSection components */}
           <button className="mt-8 px-6 py-3 bg-green-500 text-white rounded-lg hover:bg-green-600 transition-colors duration-200 shadow-lg">


### PR DESCRIPTION
Stationary Combustion page has been updated with new categories that fit our new guidelines.

Now every single fuel type in ghg-emission-factor-hub doc in stationary combustion should fit into these categories.

For documentation on what fuel type goes in what category and units look in Unit Document in OneDrive.