### PR TITLE
Feat (backend): Final Report Calculations w/ Stationary Combustion

### DIFF
--- a/backend/CFCBackend/src/main/java/com/cfc/cfcbackend/controller/FinalReportController.java
+++ b/backend/CFCBackend/src/main/java/com/cfc/cfcbackend/controller/FinalReportController.java
@@ -14,6 +14,7 @@ public class FinalReportController {
     @ResponseBody
     @GetMapping("/final-report")
     public double calcTotal() {
+        
         return 0;
     }
 }

--- a/backend/CFCBackend/src/main/java/com/cfc/cfcbackend/controller/FinalReportController.java
+++ b/backend/CFCBackend/src/main/java/com/cfc/cfcbackend/controller/FinalReportController.java
@@ -1,0 +1,19 @@
+package com.cfc.cfcbackend.controller;
+
+import com.cfc.cfcbackend.service.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestParam;
+
+// Controller for handling all final report calculations
+
+@RestController
+public class FinalReportController {
+    
+    @ResponseBody
+    @GetMapping("/final-report")
+    public double calcTotal() {
+        return 0;
+    }
+}

--- a/backend/CFCBackend/src/main/java/com/cfc/cfcbackend/controller/Scope1Controller.java
+++ b/backend/CFCBackend/src/main/java/com/cfc/cfcbackend/controller/Scope1Controller.java
@@ -32,6 +32,9 @@ public class Scope1Controller {
     @Resource
     ModelYearConversionService modelYearConversionService;
 
+    @Resource
+    FinalReportService finalReportService;
+
     @ResponseBody
     @GetMapping("/")
     public String root() {
@@ -63,6 +66,10 @@ public class Scope1Controller {
             stationarySources.put("CH4", stationaryCombustionService.CH4PerUnit(quantity, fuelType)); 
             stationarySources.put("N2O", stationaryCombustionService.N2OPerUnit(quantity, fuelType)); 
         }
+
+        // Add calculations to total stationary combustion emissions and total overall emissions
+        stationarySources.put("calculatedTotal", finalReportService.addToTotal(totalCO2e, stationarySources));
+        stationarySources.put("calculatedStationary", finalReportService.addToTotal(totalStationary, stationarySources));
 
         return stationarySources;
     }

--- a/backend/CFCBackend/src/main/java/com/cfc/cfcbackend/controller/Scope1Controller.java
+++ b/backend/CFCBackend/src/main/java/com/cfc/cfcbackend/controller/Scope1Controller.java
@@ -41,7 +41,8 @@ public class Scope1Controller {
     // Method to calculate emissions for stationary combustion
     @ResponseBody
     @GetMapping("/stationary-combustion")
-    public Map<String, Double> stationaryCombustion(@RequestParam double quantity, @RequestParam String fuelType, @RequestParam String unit) {
+    public Map<String, Double> stationaryCombustion(@RequestParam double quantity, @RequestParam String fuelType, @RequestParam String unit,
+                                                    @RequestParam double totalCO2e, @RequestParam double totalStationary) {
 
         Map<String, Double> stationarySources = new HashMap<>(); 
         
@@ -62,6 +63,7 @@ public class Scope1Controller {
             stationarySources.put("CH4", stationaryCombustionService.CH4PerUnit(quantity, fuelType)); 
             stationarySources.put("N2O", stationaryCombustionService.N2OPerUnit(quantity, fuelType)); 
         }
+
         return stationarySources;
     }
 

--- a/backend/CFCBackend/src/main/java/com/cfc/cfcbackend/controller/Scope2Controller.java
+++ b/backend/CFCBackend/src/main/java/com/cfc/cfcbackend/controller/Scope2Controller.java
@@ -40,9 +40,9 @@ public class Scope2Controller {
 
         // If the user directly inputs emission factors, calculate market-based emissions
         else {
-            emissions.put("co2", purchasedElectricityService.purchElecCO2(electricityPurchased, co2));
-            emissions.put("ch4", purchasedElectricityService.purchElecCH4(electricityPurchased, ch4));
-            emissions.put("n2o", purchasedElectricityService.purchElecN2O(electricityPurchased, n2o));
+            emissions.put("CO2", purchasedElectricityService.purchElecCO2(electricityPurchased, co2));
+            emissions.put("CH4", purchasedElectricityService.purchElecCH4(electricityPurchased, ch4));
+            emissions.put("N2O", purchasedElectricityService.purchElecN2O(electricityPurchased, n2o));
         }
         return emissions;
     }

--- a/backend/CFCBackend/src/main/java/com/cfc/cfcbackend/service/FinalReportService.java
+++ b/backend/CFCBackend/src/main/java/com/cfc/cfcbackend/service/FinalReportService.java
@@ -36,6 +36,6 @@ public class FinalReportService {
     // Method to only add CO2 emissions to total CO2e
     // This can be used universally with total overall and total category emissions
     public double addToTotal(double total, Map<String, Double> toAdd) {
-        return total += toAdd.get("co2") + this.convertCH4ToCO2e(toAdd.get("ch4")) + this.convertN2OToCO2e(toAdd.get("n2o"));
+        return total += toAdd.get("CO2") + this.convertCH4ToCO2e(toAdd.get("CH4")) + this.convertN2OToCO2e(toAdd.get("N2O"));
     }
 }

--- a/backend/CFCBackend/src/main/java/com/cfc/cfcbackend/service/FinalReportService.java
+++ b/backend/CFCBackend/src/main/java/com/cfc/cfcbackend/service/FinalReportService.java
@@ -2,18 +2,40 @@ package com.cfc.cfcbackend.service;
 
 import org.springframework.stereotype.Service;
 
+import java.util.Map;
+import java.util.HashMap;
+
 import javax.annotation.Resource;
 
 @Service
 public class FinalReportService {
     
-    // Method to sum together all values
-    public double sumValues() {
-        return 0;
+    private final double CH4_GWP = 28;
+    private final double N2O_GWP = 265;
+
+    private final double G_TO_KG = 1000;
+
+    // We don't need to convert CO2 to CO2e as the conversion is 1-to-1
+
+    // Method to convert CH4 emissions to CO2e in kg
+    public double convertCH4ToCO2e(double ch4) {
+        return (ch4 * CH4_GWP) / G_TO_KG;
     }
 
-    // Method to convert an emission into CO2-e
-    public double convertToCO2e(double emission) {
-        return 0;
+    // Method to convert N2O emissions to CO2e in kg
+    public double convertN2OToCO2e(double n2o) {
+        return (n2o * N2O_GWP) / G_TO_KG;
+    }
+
+    // Method to only add CO2 emissions to total CO2e
+    // This can be used universally with total overall and total category emissions
+    public double addToTotal(double total, double toAdd) {
+        return total + toAdd;
+    }
+
+    // Method to only add CO2 emissions to total CO2e
+    // This can be used universally with total overall and total category emissions
+    public double addToTotal(double total, Map<String, Double> toAdd) {
+        return total += toAdd.get("co2") + this.convertCH4ToCO2e(toAdd.get("ch4")) + this.convertN2OToCO2e(toAdd.get("n2o"));
     }
 }

--- a/backend/CFCBackend/src/main/java/com/cfc/cfcbackend/service/FinalReportService.java
+++ b/backend/CFCBackend/src/main/java/com/cfc/cfcbackend/service/FinalReportService.java
@@ -1,0 +1,19 @@
+package com.cfc.cfcbackend.service;
+
+import org.springframework.stereotype.Service;
+
+import javax.annotation.Resource;
+
+@Service
+public class FinalReportService {
+    
+    // Method to sum together all values
+    public double sumValues() {
+        return 0;
+    }
+
+    // Method to convert an emission into CO2-e
+    public double convertToCO2e(double emission) {
+        return 0;
+    }
+}

--- a/backend/CFCBackend/src/test/java/com/cfc/cfcbackend/controller/Scope1ControllerTest.java
+++ b/backend/CFCBackend/src/test/java/com/cfc/cfcbackend/controller/Scope1ControllerTest.java
@@ -24,7 +24,9 @@ public class Scope1ControllerTest {
         expect.put("CO2", 17194.000244140625);
         expect.put("N2O", 839.9999618530273);
         expect.put("CH4", 6400.0);
-        Map<String, Double> actual = scope1Controller.stationaryCombustion(200, "Tires", "mmBtu");
+        expect.put("calculatedTotal", 17194.000244140625 + 222.599989891 + 179.2);
+        expect.put("calculatedStationary", 17194.000244140625 + 222.599989891 + 179.2);
+        Map<String, Double> actual = scope1Controller.stationaryCombustion(200, "Tires", "mmBtu", 0, 0);
         assertEquals(expect, actual);
     }
 


### PR DESCRIPTION
Implemented basic final report calculations. Currently only stationary combustion works, but it can be easily extended to all the other categories.

Tests are also broken, but the values are off by ~0.00000000005